### PR TITLE
Define missing baud rates for serial communication

### DIFF
--- a/serial/serial.c
+++ b/serial/serial.c
@@ -4,6 +4,14 @@
 #include <termios.h>
 #include "serial/serial.h"
 
+#ifndef B576000
+#define B576000 576000
+#endif
+
+#ifndef B1000000
+#define B1000000 1000000
+#endif
+
 int serial_open(const char *device, int baudrate)
 {
     if (!device) {


### PR DESCRIPTION
This PR adds preprocessor checks to define `B576000` and `B1000000` baud rates if they are not already defined in the system's `termios.h`. This ensures compatibility with serial devices that operate at these specific baud rates, enhancing the portability and functionality of the serial communication interface.